### PR TITLE
Install root level packages and woocommerce packages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,10 @@ cd "$WORKING_DIRECTORY" || exit
 
 echo "Installing PHP and JS dependencies..."
 npm install
+
+// Try this
+cd "$WORKING_DIRECTORY" || exit
+
 composer install || exit "$?"
 echo "Running JS Build..."
 npm run build:core || exit "$?"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@
 GENERATE_ZIP=false
 BUILD_PATH="./build"
 WORKING_DIRECTORY="$GITHUB_WORKSPACE/plugins/woocommerce"
+ZIP_DIRECTORY="plugins/woocommerce/build"
 
 # Set options based on user input
 if [ -z "$1" ]; then
@@ -49,7 +50,7 @@ if ! $GENERATE_ZIP; then
   cd "$BUILD_PATH" || exit
   zip -r "${PLUGIN_SLUG}.zip" "$PLUGIN_SLUG/"
   # Set GitHub "zip_path" output
-  echo "::set-output name=zip_path::plugins/woocommerce/build/${PLUGIN_SLUG}.zip"
+  echo "::set-output name=zip_path::${ZIP_DIRECTORY}/${PLUGIN_SLUG}.zip"
   echo "Zip file generated!"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ if ! $GENERATE_ZIP; then
   cd "$BUILD_PATH" || exit
   zip -r "${PLUGIN_SLUG}.zip" "$PLUGIN_SLUG/"
   # Set GitHub "zip_path" output
-  echo "::set-output name=zip_path::$BUILD_PATH/${PLUGIN_SLUG}.zip"
+  echo "::set-output name=zip_path::plugins/woocommerce/build/${PLUGIN_SLUG}.zip"
   echo "Zip file generated!"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,15 +19,16 @@ fi
 DEST_PATH="$BUILD_PATH/$PLUGIN_SLUG"
 echo "::set-output name=path::$DEST_PATH"
 
-cd "$WORKING_DIRECTORY" || exit
-
 echo "Installing PHP and JS dependencies..."
+
+// Install repo dependencies
 npm install
 
-// Try this
+// Install WooCommerce dependencies
 cd "$WORKING_DIRECTORY" || exit
-
+npm install
 composer install || exit "$?"
+
 echo "Running JS Build..."
 npm run build:core || exit "$?"
 echo "Cleaning up PHP dependencies..."


### PR DESCRIPTION
There are now multiple package.json files so we need to `npm install` for the project root and the one at `plugins/woocommerce`.

This PR also modifies a path for resulting zip so it can be uploaded.

@claudiosanches Since this is all a bit temporary (using NX will require an update), I'm not sure its worth it to tag another release. What do you think?