### PR TITLE
Copy composer.json as part of the build

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,7 @@ if [ -r "${WORKING_DIRECTORY}/.distignore" ]; then
   cp "${WORKING_DIRECTORY}/package.json" "$DEST_PATH" &&
   cp -r "${WORKING_DIRECTORY}/tests" "$DEST_PATH" &&
   cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH" &&
+  cp -r "${WORKING_DIRECTORY}/composer.json" "$DEST_PATH" &&
   rsync -rc --exclude-from="$WORKING_DIRECTORY/.distignore" "$WORKING_DIRECTORY/" "$DEST_PATH/"
 else
   rsync -rc "$WORKING_DIRECTORY/" "$DEST_PATH/" --delete


### PR DESCRIPTION
The production read only repo requires `composer.json` so that it may be picked up by packagist.org.

This PR ensures `composer.json` is included in zipped builds.