### PR TITLE
Zip conditional builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A GitHub Action to build WooCommerce using Composer and NPM.
 
 Use a `.distignore` file to exclude files from the build.
 
+Set an environment variable `BUILD_ENV` to "e2e" to include files relevant for e2e tests. Alternatively set the variable to "mirrors" to include files relevant for production mirror repo zips.
+
 ## Example
 
 ```yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,12 +42,24 @@ rm -rf "$BUILD_PATH"
 mkdir -p "$DEST_PATH"
 
 if [ -r "${WORKING_DIRECTORY}/.distignore" ]; then
-  mkdir -p "$DEST_PATH/node_modules/.bin" && 
-  cp "${WORKING_DIRECTORY}/node_modules/.bin/wc-e2e" "$DEST_PATH/node_modules/.bin" && 
-  cp "${WORKING_DIRECTORY}/package.json" "$DEST_PATH" &&
-  cp -r "${WORKING_DIRECTORY}/tests" "$DEST_PATH" &&
-  cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH" &&
-  cp -r "${WORKING_DIRECTORY}/composer.json" "$DEST_PATH" &&
+  if [[ -z "$BUILD_ENV" ]]; then
+    echo "No build environment specified, defaulting to a production build zip."
+  fi
+
+  if [[ "$BUILD_ENV" = "e2e" ]]; then
+    echo "Creating a zip for e2e tests."
+    mkdir -p "$DEST_PATH/node_modules/.bin" && 
+    cp "${WORKING_DIRECTORY}/node_modules/.bin/wc-e2e" "$DEST_PATH/node_modules/.bin" && 
+    cp "${WORKING_DIRECTORY}/package.json" "$DEST_PATH" &&
+    cp -r "${WORKING_DIRECTORY}/tests" "$DEST_PATH" &&
+    cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH" &&
+  fi
+
+  if [[ "$BUILD_ENV" = "mirrors" ]]; then
+    echo "Creating a zip for production mirror repository."
+    cp "${WORKING_DIRECTORY}/composer.json" "$DEST_PATH" &&
+  fi
+
   rsync -rc --exclude-from="$WORKING_DIRECTORY/.distignore" "$WORKING_DIRECTORY/" "$DEST_PATH/"
 else
   rsync -rc "$WORKING_DIRECTORY/" "$DEST_PATH/" --delete

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,11 +42,11 @@ rm -rf "$BUILD_PATH"
 mkdir -p "$DEST_PATH"
 
 if [ -r "${WORKING_DIRECTORY}/.distignore" ]; then
-  if [[ -z "$BUILD_ENV" ]]; then
+  if [ -z "$BUILD_ENV" ]; then
     echo "No build environment specified, defaulting to a production build zip."
   fi
 
-  if [[ "$BUILD_ENV" = "e2e" ]]; then
+  if [ "$BUILD_ENV" = "e2e" ]; then
     echo "Creating a zip for e2e tests."
     mkdir -p "$DEST_PATH/node_modules/.bin" && 
     cp "${WORKING_DIRECTORY}/node_modules/.bin/wc-e2e" "$DEST_PATH/node_modules/.bin" && 
@@ -55,7 +55,7 @@ if [ -r "${WORKING_DIRECTORY}/.distignore" ]; then
     cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH"
   fi
 
-  if [[ "$BUILD_ENV" = "mirrors" ]]; then
+  if [ "$BUILD_ENV" = "mirrors" ]; then
     echo "Creating a zip for production mirror repository."
     cp "${WORKING_DIRECTORY}/composer.json" "$DEST_PATH"
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,12 +52,12 @@ if [ -r "${WORKING_DIRECTORY}/.distignore" ]; then
     cp "${WORKING_DIRECTORY}/node_modules/.bin/wc-e2e" "$DEST_PATH/node_modules/.bin" && 
     cp "${WORKING_DIRECTORY}/package.json" "$DEST_PATH" &&
     cp -r "${WORKING_DIRECTORY}/tests" "$DEST_PATH" &&
-    cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH" &&
+    cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH"
   fi
 
   if [[ "$BUILD_ENV" = "mirrors" ]]; then
     echo "Creating a zip for production mirror repository."
-    cp "${WORKING_DIRECTORY}/composer.json" "$DEST_PATH" &&
+    cp "${WORKING_DIRECTORY}/composer.json" "$DEST_PATH"
   fi
 
   rsync -rc --exclude-from="$WORKING_DIRECTORY/.distignore" "$WORKING_DIRECTORY/" "$DEST_PATH/"


### PR DESCRIPTION
Establish an environmental flag `BUILD_ENV` for e2e tests and mirrors so that relevant files can be copied for those tasks only. Regular builds for Github releases or SVN repo updates will remain clean.

Associated PR in Monorepo: https://github.com/woocommerce/woocommerce/pull/31117