### PR TITLE
Make sure Grunt is available

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,9 @@ echo "Installing PHP and JS dependencies..."
 // Make sure PNPM is available
 npm install -g pnpm
 
+// Make sure Grunt is available
+npm install -g grunt-cli
+
 // Install repo dependencies
 pnpm install
 


### PR DESCRIPTION
Fix missing grunt error.

```
> woocommerce@6.0.0 build:core /github/workspace/plugins/woocommerce
> grunt && pnpm run makepot

sh: 1: grunt: not found
```