### PR TITLE
Copy woocommerce project.json for e2e environments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,7 @@ if [ -r "${WORKING_DIRECTORY}/.distignore" ]; then
     mkdir -p "$DEST_PATH/node_modules/.bin" && 
     cp "${WORKING_DIRECTORY}/node_modules/.bin/wc-e2e" "$DEST_PATH/node_modules/.bin" && 
     cp "${WORKING_DIRECTORY}/package.json" "$DEST_PATH" &&
+    cp "${WORKING_DIRECTORY}/project.json" "$DEST_PATH" &&
     cp -r "${WORKING_DIRECTORY}/tests" "$DEST_PATH" &&
     cp -r "${WORKING_DIRECTORY}/sample-data" "$DEST_PATH"
   fi


### PR DESCRIPTION
`project.json` is required for e2e smoke testing. This change ensures it will be available in that environment.