### PR TITLE
Reference correct build script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ cd "$WORKING_DIRECTORY" || exit
 composer install || exit "$?"
 
 echo "Running JS Build..."
-pnpm run build:core || exit "$?"
+pnpm run build || exit "$?"
 echo "Cleaning up PHP dependencies..."
 composer install --no-dev || exit "$?"
 


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/pull/32689 standardizes `pnpm` build scripts. As a result, `build:core` is no longer needed and `build` now performs the same task.

This PR updates this Github Action to reflect this.